### PR TITLE
Added GitHub URL

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -41,4 +41,4 @@ Imports:
     ggplot2
 Suggests: knitr (>= 1.20)
 VignetteBuilder: knitr
-URL: https://www.ecdc.europa.eu/en/annual-epidemiological-reports
+URL: https://www.ecdc.europa.eu/en/annual-epidemiological-reports, https://github.com/EU-ECDC/EpiReport


### PR DESCRIPTION
The github URL is added to the description. This will give cran users awareness of the GitHub location.

For an example see https://github.com/tidyverse/dplyr/blob/main/DESCRIPTION     